### PR TITLE
Add explicit dependency on commons-lang3

### DIFF
--- a/json-serde/pom.xml
+++ b/json-serde/pom.xml
@@ -121,6 +121,12 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>
 


### PR DESCRIPTION
commons-lang3 has been used as a compile time dependency since f1781301f2a6b13d15e46d51ce6a8ebe6ac17752 but no explicit dependency was added.

This used to work since hadoop-common, hive-exec, coral etc. and many other libraries pull is commons-lang3 as a transitive dependency and this meant that usually it was on the classpath leading to things working.

After a combination of https://github.com/trinodb/trino/pull/18444, https://github.com/trinodb/trino/pull/18445 and
https://github.com/trinodb/trino-hive-apache/pull/49 this no longer works reliably leading to failures like:

    2023-08-09 01:21:23 SEVERE: Failure cause:
    io.trino.tempto.query.QueryExecutionException: java.sql.SQLException: Query failed (#20230808_193622_00006_ubxkq): org/apache/commons/lang3/tuple/Pair
    ...
    Caused by: java.lang.NoClassDefFoundError: org/apache/commons/lang3/tuple/Pair
        at org.openx.data.jsonserde.objectinspector.JsonObjectInspectorFactory.getJsonObjectInspectorFromTypeInfo(JsonObjectInspectorFactory.java:66)
        at org.openx.data.jsonserde.JsonSerDe.initialize(JsonSerDe.java:150)
        at io.trino.plugin.hive.util.HiveReaderUtil.initializeDeserializer(HiveReaderUtil.java:273)
        at io.trino.plugin.hive.util.HiveReaderUtil.getDeserializer(HiveReaderUtil.java:238)
        at io.trino.plugin.hive.GenericHiveRecordCursor.<init>(GenericHiveRecordCursor.java:141)
        at io.trino.plugin.hive.GenericHiveRecordCursorProvider.lambda$createRecordCursor$1(GenericHiveRecordCursorProvider.java:109)
        at io.trino.hdfs.authentication.NoHdfsAuthentication.doAs(NoHdfsAuthentication.java:25)
        at io.trino.hdfs.HdfsEnvironment.doAs(HdfsEnvironment.java:125)
        at io.trino.plugin.hive.GenericHiveRecordCursorProvider.createRecordCursor(GenericHiveRecordCursorProvider.java:96)
        at io.trino.plugin.hive.HivePageSourceProvider.createHivePageSource(HivePageSourceProvider.java:256)
        at io.trino.plugin.hive.HivePageSourceProvider.createPageSource(HivePageSourceProvider.java:154)
	...
        at io.trino.plugin.base.classloader.ClassLoaderSafeConnectorPageSourceProvider.createPageSource(ClassLoaderSafeConnectorPageSourceProvider.java:48)
        at io.trino.split.PageSourceManager.createPageSource(PageSourceManager.java:61)
        at io.trino.operator.TableScanOperator.getOutput(TableScanOperator.java:296)
        at io.trino.operator.Driver.processInternal(Driver.java:395)
        at io.trino.operator.Driver.lambda$process$8(Driver.java:298)
        at io.trino.operator.Driver.tryWithLock(Driver.java:694)
        at io.trino.operator.Driver.process(Driver.java:290)
        at io.trino.operator.Driver.processForDuration(Driver.java:261)
        at io.trino.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:887)
        at io.trino.execution.executor.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:187)
        at io.trino.execution.executor.TaskExecutor$TaskRunner.run(TaskExecutor.java:555)
        at io.trino.$gen.Trino_422_e_49_gb1b5240____20230808_193431_2.run(Unknown Source)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
    Caused by: java.lang.ClassNotFoundException: org.apache.commons.lang3.tuple.Pair
        at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:445)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:587)
        at io.trino.server.PluginClassLoader.loadClass(PluginClassLoader.java:128)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:520)
        ... 27 more